### PR TITLE
Fixed dotted circle deletion in incorrectly ordered Om sequence

### DIFF
--- a/qa/shaping_tests/javanese.json
+++ b/qa/shaping_tests/javanese.json
@@ -443,6 +443,18 @@
             "expectation": "pa_cakra=0+1221|cecaktelu.ns_cecak.ns=0@-156,10+0",
             "note": "googlefonts/noto-fonts#2332",
             "only": "NotoSansJavanese-Regular.ttf"
+        },
+        {
+            "input": "ꦎꦴꦀ",
+            "expectation": "okara=0+967|panyangga.ns=0@15,10+0|uni25CC=0+594|tarung=0+413",
+            "note": "googlefonts/javanese#32",
+            "only": "NotoSansJavanese-Regular.ttf"
+        },
+        {
+            "input": "ꦎꦀꦴ",
+            "expectation": "okara=0+967|panyangga.ns=0@15,10+0|uni25CC=0+594|tarung=0+413",
+            "note": "googlefonts/javanese#32",
+            "only": "NotoSansJavanese-Regular.ttf"
         }
     ]
 }

--- a/qa/shaping_tests/javanese.json
+++ b/qa/shaping_tests/javanese.json
@@ -446,7 +446,7 @@
         },
         {
             "input": "ꦎꦴꦀ",
-            "expectation": "okara=0+967|panyangga.ns=0@15,10+0|uni25CC=0+594|tarung=0+413",
+            "expectation": "om_javanese=0+1367",
             "note": "googlefonts/javanese#32",
             "only": "NotoSansJavanese-Regular.ttf"
         },

--- a/sources/NotoSansJavanese.glyphs
+++ b/sources/NotoSansJavanese.glyphs
@@ -703,7 +703,7 @@ code = "lookup CakraPasLigature2 {\012    sub pa.pas_cakra u.ns by pa.pas_cakra_
 name = pres;
 },
 {
-code = "\012# [('java', 'dflt')]\012    lookup ChainedContextualGSUB19;\012\012# Use alternate below marks on all pasangans; see #6\012sub @class79 [u.ns uu.ns keret.ns pengkal]' lookup SingleSubstitution28;\012\012# [('java', 'dflt')]\012    lookup ContextualGSUB20;\012\012# [('java', 'dflt')]\012    lookup ChainedContextualGSUB33;\012\012lookup OmLigature {\012    lookupflag MarkAttachmentType @abovemarks;\012    sub okara panyangga.ns uni25CC tarung by om_javanese;\012    sub okara panyangga.ns tarung by om_javanese;\012    sub okara tarung panyangga.ns by om_javanese;\012} OmLigature;\012";
+code = "\012# [('java', 'dflt')]\012    lookup ChainedContextualGSUB19;\012\012# Use alternate below marks on all pasangans; see #6\012sub @class79 [u.ns uu.ns keret.ns pengkal]' lookup SingleSubstitution28;\012\012# [('java', 'dflt')]\012    lookup ContextualGSUB20;\012\012# [('java', 'dflt')]\012    lookup ChainedContextualGSUB33;\012\012lookup OmLigature {\012    lookupflag MarkAttachmentType @abovemarks;\012    sub okara tarung panyangga.ns by om_javanese;\012} OmLigature;\012";
 name = psts;
 },
 {


### PR DESCRIPTION
fixes #32, as well as the problem noted in https://github.com/notofonts/javanese/issues/1#issuecomment-1160749938

Note: Noto Sans Javanese before this fix allowed two sequences for the Javanese Om:

the correct:

`ꦎ A98E JAVANESE LETTER O` 
`ꦴ A9B4 JAVANESE VOWEL SIGN TARUNG` (long -aa vowel mark)
`ꦀ A980 JAVANESE SIGN PANYANGGA` (candrabindu)

and the incorrect:

`ꦎ A98E JAVANESE LETTER O` 
`ꦀ A980 JAVANESE SIGN PANYANGGA`
`ꦴ A9B4 JAVANESE VOWEL SIGN TARUNG`

Because the second sequence is considered incorrect by Unicode (the correct order for Javanese should be in phonetic order), a dotted circle is automatically inserted between the `PANYANGGA` and `TARUNG`, as `PANYANGGA` should always occur after any vowel marks in memory. To get around this, the shaping rules went back and deleted the dotted circle. This had the side effect of making the sequence:

`ꦎ A98E JAVANESE LETTER O` 
`ꦀ A980 JAVANESE SIGN PANYANGGA`
`◌ 25CC DOTTED CIRCLE`
`ꦴ A9B4 JAVANESE VOWEL SIGN TARUNG`

*also* display as the `om_javanese` glyph.

So to prevent the sequence with `25CC` from rendering as `om_javanese`, we need to also remove the functionality that shapes the incorrect order as `om_javanese`. 

**This should be fine, and preferable**

Based on my research, the incorrect sequence is practically not found in the wild—the only usages that comes up on Google are a bot-driven site that attempts to read PDFs, and the first result is actually this repo.

On the other hand, the correct sequence has 6 pages of legitimate usage, including Wiktionary, Wikipedia, and many social media posts.

Fixing Noto Sans Javanese to not allow the incorrect order to render correctly would be helpful for not propagating the incorrect order, in addition to solving this disappearing dotted circle issue.